### PR TITLE
Block the Session Registeration before starting i3

### DIFF
--- a/session/i3-gnome
+++ b/session/i3-gnome
@@ -2,7 +2,7 @@
 
 # Register with gnome-session so that it does not kill the whole session thinking it is dead.
 test -n "$DESKTOP_AUTOSTART_ID" && {
-	dbus-send --session --dest=org.gnome.SessionManager "/org/gnome/SessionManager" org.gnome.SessionManager.RegisterClient "string:i3-gnome" "string:$DESKTOP_AUTOSTART_ID"
+	dbus-send --print-reply --session --dest=org.gnome.SessionManager "/org/gnome/SessionManager" org.gnome.SessionManager.RegisterClient "string:i3-gnome" "string:$DESKTOP_AUTOSTART_ID"
 }
 
 exec i3


### PR DESCRIPTION
This fixes the issue under Gnome 3.16 where  Gnome exit and complains about i3-gnome
not being registered before timeout.
